### PR TITLE
OFS-99: fixing uuid field when the user is anonymous

### DIFF
--- a/calculation/models.py
+++ b/calculation/models.py
@@ -28,7 +28,7 @@ class CalculationRules(core_models.HistoryBusinessModel):
         if isinstance(user, ResolveInfo):
             user = user.context.user
         if settings.ROW_SECURITY and user.is_anonymous:
-            return queryset.filter(id=-1)
+            return queryset.filter(id=None)
         if settings.ROW_SECURITY:
             pass
         return queryset
@@ -61,7 +61,7 @@ class CalculationRulesDetails(core_models.HistoryModel):
         if isinstance(user, ResolveInfo):
             user = user.context.user
         if settings.ROW_SECURITY and user.is_anonymous:
-            return queryset.filter(id=-1)
+            return queryset.filter(id=None)
         if settings.ROW_SECURITY:
             pass
         return queryset


### PR DESCRIPTION
Please merhe this fix, I've fixed this issue because there is no id as an integer, but UUID and "None" should be here in filtering when the user is anonymous etc.

Another pull requests related to this fix. https://github.com/openimis/openimis-be-policyholder_py/pull/10
https://github.com/openimis/openimis-be-contribution_plan_py/pull/6