### PR TITLE
OFS-211: retrieve CalculationRuleData and Params in graphQl queries

### DIFF
--- a/calculation/gql/__init__.py
+++ b/calculation/gql/__init__.py
@@ -1,1 +1,0 @@
-from .gql_types import *

--- a/calculation/schema.py
+++ b/calculation/schema.py
@@ -19,8 +19,8 @@ class CalculationRulesListGQLType(graphene.ObjectType):
 
 class Query(graphene.ObjectType):
 
-    calculation_rule = graphene.Field(
-        CalculationRulesGQLType,
+    calculation_rules_by_class_name = graphene.Field(
+        CalculationRulesListGQLType,
         class_name=graphene.Argument(graphene.String, required=True),
     )
 
@@ -28,20 +28,27 @@ class Query(graphene.ObjectType):
         CalculationRulesListGQLType,
     )
 
-    def resolve_calculation_rule(parent, info, **kwargs):
+    def resolve_calculation_rules_by_class_name(parent, info, **kwargs):
         class_name = kwargs.get("class_name", None)
-        calculation_object = None
+        list_cr = []
         if class_name:
-            calculation_object = get_rule_name(class_name=class_name)[0][1]
-        return CalculationRulesGQLType(
-            calculation_class_name=calculation_object.calculation_rule_name,
-            status=calculation_object.status,
-            description=calculation_object.description,
-            uuid=calculation_object.uuid,
-            class_param=calculation_object.impacted_class_parameter,
-            date_valid_from=calculation_object.date_valid_from,
-            date_valid_to=calculation_object.date_valid_to,
-        )
+            list_signal_result = get_rule_name(class_name=class_name)
+            if list_signal_result:
+                for sr in list_signal_result:
+                    rule = sr[1]
+                    if rule:
+                        list_cr.append(
+                            CalculationRulesGQLType(
+                                calculation_class_name=rule.calculation_rule_name,
+                                status=rule.status,
+                                description=rule.description,
+                                uuid=rule.uuid,
+                                class_param=rule.impacted_class_parameter,
+                                date_valid_from=rule.date_valid_from,
+                                date_valid_to=rule.date_valid_to,
+                            )
+                        )
+        return CalculationRulesListGQLType(list_cr)
 
     def resolve_calculation_rules(parent, info, **kwargs):
         list_cr = []

--- a/calculation/schema.py
+++ b/calculation/schema.py
@@ -1,0 +1,60 @@
+import graphene
+from .apps import CALCULATION_RULES
+from .services import get_rule_name
+
+
+class CalculationRulesGQLType(graphene.ObjectType):
+    calculation_class_name = graphene.String()
+    status = graphene.String()
+    description = graphene.String()
+    uuid = graphene.UUID()
+    class_param = graphene.JSONString()
+    date_valid_from = graphene.Date()
+    date_valid_to = graphene.Date()
+
+
+class CalculationRulesListGQLType(graphene.ObjectType):
+    calculation_rules = graphene.List(CalculationRulesGQLType)
+
+
+class Query(graphene.ObjectType):
+
+    calculation_rule = graphene.Field(
+        CalculationRulesGQLType,
+        class_name=graphene.Argument(graphene.String, required=True),
+    )
+
+    calculation_rules = graphene.Field(
+        CalculationRulesListGQLType,
+    )
+
+    def resolve_calculation_rule(parent, info, **kwargs):
+        class_name = kwargs.get("class_name", None)
+        calculation_object = None
+        if class_name:
+            calculation_object = get_rule_name(class_name=class_name)[0][1]
+        return CalculationRulesGQLType(
+            calculation_class_name=calculation_object.calculation_rule_name,
+            status=calculation_object.status,
+            description=calculation_object.description,
+            uuid=calculation_object.uuid,
+            class_param=calculation_object.impacted_class_parameter,
+            date_valid_from=calculation_object.date_valid_from,
+            date_valid_to=calculation_object.date_valid_to,
+        )
+
+    def resolve_calculation_rules(parent, info, **kwargs):
+        list_cr = []
+        for cr in CALCULATION_RULES:
+            list_cr.append(
+                CalculationRulesGQLType(
+                    calculation_class_name=cr.calculation_rule_name,
+                    status=cr.status,
+                    description=cr.description,
+                    uuid=cr.uuid,
+                    class_param=cr.impacted_class_parameter,
+                    date_valid_from=cr.date_valid_from,
+                    date_valid_to=cr.date_valid_to,
+                )
+            )
+        return CalculationRulesListGQLType(list_cr)

--- a/calculation/schema.py
+++ b/calculation/schema.py
@@ -35,6 +35,8 @@ class Query(graphene.ObjectType):
             list_signal_result = get_rule_name(class_name=class_name)
             if list_signal_result:
                 for sr in list_signal_result:
+                    # get the signal result - calculation rule object
+                    #  related to the input class name
                     rule = sr[1]
                     if rule:
                         list_cr.append(


### PR DESCRIPTION
TICKET - OFS-211 https://openimis.atlassian.net/browse/OFS-211

In that PR I want to add schema for graphQl in Calculation module - so as to retrieve data from CalculationRules and fetch Params linked to the class_name and instance.  I have three queries - fetch all calculation rules, fetch all calculation rules related to the class_name, fetch params related to the  class_name, instance model name and instance uuid. 

![Screenshot from 2021-02-18 17-01-34](https://user-images.githubusercontent.com/52816247/108508842-b7eb4780-72bc-11eb-827a-ba720fe6bf02.png)
![Screenshot from 2021-02-19 13-54-09](https://user-images.githubusercontent.com/52816247/108508845-b91c7480-72bc-11eb-82f0-185261156936.png)

